### PR TITLE
Updates 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore PyCharm files
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/fire.py
+++ b/fire.py
@@ -22,7 +22,7 @@ class FireProx(object):
         self.api_list = []
         self.client = None
 
-        if self.access_key and self.access_key:
+        if self.access_key and self.secret_access_key:
             if not self.region:
                 self.error('Please provide a region with AWS credentials')
 

--- a/fire.py
+++ b/fire.py
@@ -345,26 +345,34 @@ class FireProx(object):
         return response['uri']
 
 
-parser = argparse.ArgumentParser(description='FireProx API Gateway Manager')
-parser.add_argument('--access_key',
-    help='AWS Access Key', type=str, default=None)
-parser.add_argument('--secret_access_key',
-    help='AWS Secret Access Key', type=str, default=None)
-parser.add_argument('--region',
-    help='AWS Region', type=str, default=None)
-parser.add_argument('--command',
-    help='Commands: list, create, delete, update', type=str, default=None)
-parser.add_argument('--api_id',
-    help='API ID', type=str, required=False)
-parser.add_argument('--url',
-    help='URL end-point', type=str, required=False)
-args = parser.parse_args()
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments and return namespace
 
-fp = FireProx(args)
+    :return:
+    """
+    parser = argparse.ArgumentParser(description='FireProx API Gateway Manager')
+    parser.add_argument('--access_key',
+        help='AWS Access Key', type=str, default=None)
+    parser.add_argument('--secret_access_key',
+        help='AWS Secret Access Key', type=str, default=None)
+    parser.add_argument('--region',
+        help='AWS Region', type=str, default=None)
+    parser.add_argument('--command',
+        help='Commands: list, create, delete, update', type=str, default=None)
+    parser.add_argument('--api_id',
+        help='API ID', type=str, required=False)
+    parser.add_argument('--url',
+        help='URL end-point', type=str, required=False)
+    return parser.parse_args()
 
 
 def main():
+    """Run the main program
 
+    :return:
+    """
+    args = parse_arguments()
+    fp = FireProx(args)
     if args.command == 'list':
         print(f'Listing API\'s...')
         result = fp.list_api()

--- a/fire.py
+++ b/fire.py
@@ -32,10 +32,8 @@ class FireProx(object):
         if not self.command:
             self.error('Please provide a valid command')
 
-
     def __str__(self):
         return 'FireProx()'
-
 
     def create_config(self):
         self.clear_creds()
@@ -70,7 +68,6 @@ class FireProx(object):
         except:
             return False
 
-
     def clear_creds(self):
         try:
             root_path = f'{str(Path.home())}\\.aws'
@@ -80,9 +77,8 @@ class FireProx(object):
         except:
             return False
 
-
     def load_creds(self):
-        if not any([self.access_key,self.secret_access_key]):
+        if not any([self.access_key, self.secret_access_key]):
             try:
                 if not self.region:
                     self.client = boto3.client('apigateway')
@@ -113,11 +109,9 @@ class FireProx(object):
         else:
             return False
 
-
     def error(self, error):
         parser.print_help()
         sys.exit(error)
-
 
     def get_template(self):
         url = self.url
@@ -208,12 +202,11 @@ class FireProx(object):
           }
         }
         '''
-        template = template.replace('{{url}}',url)
-        template = template.replace('{{title}}',title)
-        template = template.replace('{{version_date}}',version_date)
+        template = template.replace('{{url}}', url)
+        template = template.replace('{{title}}', title)
+        template = template.replace('{{version_date}}', version_date)
 
         return str.encode(template)
-
 
     def create_api(self, url):
         if not url:
@@ -224,7 +217,7 @@ class FireProx(object):
         template = self.get_template()
         response = self.client.import_rest_api(
             parameters={
-                'endpointConfigurationTypes':'REGIONAL'
+                'endpointConfigurationTypes': 'REGIONAL'
             },
             body=template
         )
@@ -238,7 +231,6 @@ class FireProx(object):
             resource_id,
             proxy_url
         )
-
 
     def update_api(self, api_id, url):
         if not any([api_id, url]):
@@ -258,14 +250,13 @@ class FireProx(object):
                     {
                         'op': 'replace',
                         'path': '/uri',
-                        'value': '{}/{}'.format(url,r'{proxy}'),
+                        'value': '{}/{}'.format(url, r'{proxy}'),
                     },
                 ]
             )
-            return response['uri'].replace('/{proxy}','') == url
+            return response['uri'].replace('/{proxy}', '') == url
         else:
             self.error(f'Unable to update, no valid resource for {api_id}')
-
 
     def delete_api(self, api_id):
         if not api_id:
@@ -280,7 +271,6 @@ class FireProx(object):
                 return True
         return False
 
-
     def list_api(self, deleted_api_id=None):
         response = self.client.get_rest_apis()
         for item in response['items']:
@@ -288,22 +278,20 @@ class FireProx(object):
                 created_dt = item['createdDate']
                 api_id = item['id']
                 name = item['name']
-                proxy_url = self.get_integration(api_id).replace('{proxy}','')
+                proxy_url = self.get_integration(api_id).replace('{proxy}', '')
                 url = f'https://{api_id}.execute-api.{self.region}.amazonaws.com/fireprox/'
                 if not api_id == deleted_api_id:
                     print(f'[{created_dt}] ({api_id}) {name}: {url} => {proxy_url}')
             except:
                 pass
-           
+
         return response['items']
 
-
     def store_api(self, api_id, name, created_dt, version_dt, url,
-        resource_id, proxy_url):
+                  resource_id, proxy_url):
         print(
             f'[{created_dt}] ({api_id}) {name} => {proxy_url} ({url})'
         )
-
 
     def create_deployment(self, api_id):
         if not api_id:
@@ -317,8 +305,7 @@ class FireProx(object):
         )
         resource_id = response['id']
         return (resource_id,
-            f'https://{api_id}.execute-api.{self.region}.amazonaws.com/fireprox/')
-
+                f'https://{api_id}.execute-api.{self.region}.amazonaws.com/fireprox/')
 
     def get_resource(self, api_id):
         if not api_id:
@@ -331,7 +318,6 @@ class FireProx(object):
             if item_path == '/{proxy+}':
                 return item_id
         return None
-
 
     def get_integration(self, api_id):
         if not api_id:
@@ -352,17 +338,17 @@ def parse_arguments() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(description='FireProx API Gateway Manager')
     parser.add_argument('--access_key',
-        help='AWS Access Key', type=str, default=None)
+                        help='AWS Access Key', type=str, default=None)
     parser.add_argument('--secret_access_key',
-        help='AWS Secret Access Key', type=str, default=None)
+                        help='AWS Secret Access Key', type=str, default=None)
     parser.add_argument('--region',
-        help='AWS Region', type=str, default=None)
+                        help='AWS Region', type=str, default=None)
     parser.add_argument('--command',
-        help='Commands: list, create, delete, update', type=str, default=None)
+                        help='Commands: list, create, delete, update', type=str, default=None)
     parser.add_argument('--api_id',
-        help='API ID', type=str, required=False)
+                        help='API ID', type=str, required=False)
     parser.add_argument('--url',
-        help='URL end-point', type=str, required=False)
+                        help='URL end-point', type=str, required=False)
     return parser.parse_args()
 
 
@@ -387,10 +373,10 @@ def main():
 
     elif args.command == 'update':
         print(f'Updating {fp.api_id} => {fp.url}...')
-        result = fp.update_api(fp.api_id,fp.url)
+        result = fp.update_api(fp.api_id, fp.url)
         success = 'Success!' if result else 'Failed!'
         print(f'API Update Complete: {success}')
-   
+
 
 if __name__ == '__main__':
     main()

--- a/fire.py
+++ b/fire.py
@@ -78,6 +78,7 @@ class FireProx(object):
             if config_profile_section not in config:
                 print(f'Please create a section for {self.profile_name} in your ~/.aws/config file')
                 return False
+            self.region = config[config_profile_section].get('region', 'us-east-1')
             try:
                 self.client = boto3.session.Session(profile_name=self.profile_name).client('apigateway')
                 self.client.get_account()
@@ -152,6 +153,12 @@ class FireProx(object):
                     "in": "path",
                     "required": true,
                     "type": "string"
+                  },
+                  {
+                    "name": "X-My-X-Forwarded-For",
+                    "in": "header",
+                    "required": false,
+                    "type": "string"
                   }
                 ],
                 "responses": {},
@@ -163,7 +170,8 @@ class FireProx(object):
                     }
                   },
                   "requestParameters": {
-                    "integration.request.path.proxy": "method.request.path.proxy"
+                    "integration.request.path.proxy": "method.request.path.proxy",
+                    "integration.request.header.X-Forwarded-For": "method.request.header.X-My-X-Forwarded-For"
                   },
                   "passthroughBehavior": "when_no_match",
                   "httpMethod": "ANY",
@@ -186,6 +194,12 @@ class FireProx(object):
                     "in": "path",
                     "required": true,
                     "type": "string"
+                  },
+                  {
+                    "name": "X-My-X-Forwarded-For",
+                    "in": "header",
+                    "required": false,
+                    "type": "string"
                   }
                 ],
                 "responses": {},
@@ -197,7 +211,8 @@ class FireProx(object):
                     }
                   },
                   "requestParameters": {
-                    "integration.request.path.proxy": "method.request.path.proxy"
+                    "integration.request.path.proxy": "method.request.path.proxy",
+                    "integration.request.header.X-Forwarded-For": "method.request.header.X-My-X-Forwarded-For"
                   },
                   "passthroughBehavior": "when_no_match",
                   "httpMethod": "ANY",

--- a/fire.py
+++ b/fire.py
@@ -9,10 +9,12 @@ import datetime
 import tzlocal
 import argparse
 import json
+from typing import Tuple, Callable
 
 
 class FireProx(object):
-    def __init__(self, arguments):
+    def __init__(self, arguments: argparse.Namespace, help_text: str):
+        self.profile_name = arguments.profile_name
         self.access_key = arguments.access_key
         self.secret_access_key = arguments.secret_access_key
         self.region = arguments.region
@@ -21,6 +23,7 @@ class FireProx(object):
         self.url = arguments.url
         self.api_list = []
         self.client = None
+        self.help = help_text
 
         if self.access_key and self.secret_access_key:
             if not self.region:
@@ -110,7 +113,7 @@ class FireProx(object):
             return False
 
     def error(self, error):
-        parser.print_help()
+        print(self.help)
         sys.exit(error)
 
     def get_template(self):
@@ -331,12 +334,14 @@ class FireProx(object):
         return response['uri']
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments() -> Tuple[argparse.Namespace, str]:
     """Parse command line arguments and return namespace
 
-    :return:
+    :return: Namespace for arguments and help text as a tuple
     """
     parser = argparse.ArgumentParser(description='FireProx API Gateway Manager')
+    parser.add_argument('--profile_name',
+                        help='AWS Profile Name to store/retrieve credentials', type=str, default='fireprox')
     parser.add_argument('--access_key',
                         help='AWS Access Key', type=str, default=None)
     parser.add_argument('--secret_access_key',
@@ -349,7 +354,7 @@ def parse_arguments() -> argparse.Namespace:
                         help='API ID', type=str, required=False)
     parser.add_argument('--url',
                         help='URL end-point', type=str, required=False)
-    return parser.parse_args()
+    return parser.parse_args(), parser.format_help()
 
 
 def main():
@@ -357,8 +362,8 @@ def main():
 
     :return:
     """
-    args = parse_arguments()
-    fp = FireProx(args)
+    args, help_text = parse_arguments()
+    fp = FireProx(args, help_text)
     if args.command == 'list':
         print(f'Listing API\'s...')
         result = fp.list_api()

--- a/fire.py
+++ b/fire.py
@@ -73,7 +73,11 @@ class FireProx(object):
         config = configparser.ConfigParser()
         config.read(os.path.expanduser('~/.aws/config'))
         # If profile in files, try it, but flow through if it does not work
-        if self.profile_name in credentials and self.profile_name in config:
+        config_profile_section = f'profile {self.profile_name}'
+        if self.profile_name in credentials:
+            if config_profile_section not in config:
+                print(f'Please create a section for {self.profile_name} in your ~/.aws/config file')
+                return False
             try:
                 self.client = boto3.session.Session(profile_name=self.profile_name).client('apigateway')
                 self.client.get_account()
@@ -94,9 +98,9 @@ class FireProx(object):
                 self.region = self.client._client_config.region_name
                 # Save/overwrite config if profile specified
                 if self.profile_name:
-                    if self.profile_name not in config:
-                        config.add_section(self.profile_name)
-                    config[self.profile_name]['region'] = self.region
+                    if config_profile_section not in config:
+                        config.add_section(config_profile_section)
+                    config[config_profile_section]['region'] = self.region
                     with open(os.path.expanduser('~/.aws/config'), 'w') as file:
                         config.write(file)
                     if self.profile_name not in credentials:

--- a/fire.py
+++ b/fire.py
@@ -18,7 +18,7 @@ class FireProx(object):
         self.profile_name = arguments.profile_name
         self.access_key = arguments.access_key
         self.secret_access_key = arguments.secret_access_key
-        self.session_token= arguments.session_token
+        self.session_token = arguments.session_token
         self.region = arguments.region
         self.command = arguments.command
         self.api_id = arguments.api_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 tldextract
 tzlocal
 bs4
+lxml


### PR DESCRIPTION
A few changes:

- Don't clobber the user's ~/.aws/config and ~/.aws/credentials files

- Use instance profile if no credentials provided

- Use existing profile if provided (and it works)

- Added ability to specify the session token if using STS credentials

- Create/overwrite named profile section in config/credentials file if new credentials and profile name provided.  This should keep existing entries.

- Reformat according to what PyCharm thinks is PEP8

- Replace X-Forwarded-For with X-My-X-Forwarded-For if supplied (is not required)
