### PR TITLE
Update README.md to state Python 3.6 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ cd fireprox
 (fireprox) ~/fireprox$ python fire.py
 ```
 
-Note that Python 3 is required.
+Note that Python 3.6 is required.
 
 Building a Docker image: (Currently does not work on Docker for Windows, possibly due to line endings in entrypoint.sh.)
 ```bash


### PR DESCRIPTION
In order to use "f" strings the requirement for Python is 3.6. I spent a bit of time trying to debug what wasn't working in Python 3.5 until I finally googled the right thing to find out 3.5 doesn't support f-strings. Might be worth mentioning.