### PR TITLE
Hardcoded X-Forwarded-For header to 127.0.0.1

### DIFF
--- a/fire.py
+++ b/fire.py
@@ -153,12 +153,6 @@ class FireProx(object):
                     "in": "path",
                     "required": true,
                     "type": "string"
-                  },
-                  {
-                    "name": "X-My-X-Forwarded-For",
-                    "in": "header",
-                    "required": false,
-                    "type": "string"
                   }
                 ],
                 "responses": {},
@@ -171,7 +165,7 @@ class FireProx(object):
                   },
                   "requestParameters": {
                     "integration.request.path.proxy": "method.request.path.proxy",
-                    "integration.request.header.X-Forwarded-For": "method.request.header.X-My-X-Forwarded-For"
+                    "integration.request.header.X-Forwarded-For": "'127.0.0.1'"
                   },
                   "passthroughBehavior": "when_no_match",
                   "httpMethod": "ANY",
@@ -194,12 +188,6 @@ class FireProx(object):
                     "in": "path",
                     "required": true,
                     "type": "string"
-                  },
-                  {
-                    "name": "X-My-X-Forwarded-For",
-                    "in": "header",
-                    "required": false,
-                    "type": "string"
                   }
                 ],
                 "responses": {},
@@ -212,7 +200,7 @@ class FireProx(object):
                   },
                   "requestParameters": {
                     "integration.request.path.proxy": "method.request.path.proxy",
-                    "integration.request.header.X-Forwarded-For": "method.request.header.X-My-X-Forwarded-For"
+                    "integration.request.header.X-Forwarded-For": "'127.0.0.1'"
                   },
                   "passthroughBehavior": "when_no_match",
                   "httpMethod": "ANY",


### PR DESCRIPTION
Current version exposes the source IP to the destination via the `X-Forwarded-For` header unless the source http request sets the custom header `X-My-X-Forwarded-For` to some value.

This version hardcodes the `X-Forwarded-For` to 127.0.0.1 regardless of headers in source http request.

<img width="535" alt="Screenshot 2019-04-27 at 1 24 21 AM" src="https://user-images.githubusercontent.com/795867/56825878-1bf18000-688d-11e9-81b0-0b00db55c62e.png">
