### PR TITLE
Add simple IP test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ optional arguments:
 * Examples
 	* examples/google.py: Use a FireProx proxy to scrape Google search.
 	* examples/bing.py: Use a FireProx proxy to scrape Bing search.
+	* examples/testip.py: Simply display the IP a fireprox used for a request
          
 ## Installation ##
 You can install and run with the following command:

--- a/examples/testip.py
+++ b/examples/testip.py
@@ -1,0 +1,15 @@
+# Before using this script, use fireprox to create a proxy to an IP reporting api.
+# Warning: some IP reporting apis take X-Forwarded-For and display that instead
+# of the actual IP the request came from. I've found that https://api.my-ip.io/ip
+# IGNORES the X-Forwarded-For header, allowing you to see the AWS IP that made
+# the request
+
+# Once the fireprox proxy is made to a site like https://api.my-ip.io/ip run:
+# python testip.py <fireprox_url>
+# Each execution should show a new IP
+
+import requests
+import sys
+
+url = sys.argv[1]
+print(requests.get(url).text)


### PR DESCRIPTION
Added an example python script which can be used to test the fireprox and veiw the AWS IP address that was used to make the request