### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.7-alpine
-RUN apk add git libxml2-dev libxslt-dev build-base
-RUN git clone https://github.com/ustayready/fireprox /root/fireprox
-RUN cd /root/fireprox && pip install -r requirements.txt
+FROM python:3.7-slim
+
 WORKDIR /root/fireprox
-COPY entrypoint.sh /tmp/entrypoint.sh
-RUN chmod +x /tmp/entrypoint.sh
-ENTRYPOINT ["/tmp/entrypoint.sh"]
+COPY . .
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "/root/fireprox/fire.py"]


### PR DESCRIPTION
Suggest to refactor the Dockerfile:

* base the image on python:3.7-slim instead of python:3.7-alpine
* when doing that, there's no need for build tools as there's binary versions of required python packages
* as we're not installing the build tools, the resulting image size is smaller
* this also makes the docker image build process **much** faster (xml lib build take a while)
* there's no need for entrypoint.sh, updated ENTRYPOINT to just run python fire.py
* updated Dockerfile should be run from the cloned repo - it just copies files, doesn't do `git clone`