### PR TITLE
When using a named profile, specify a region when establishing a session

### DIFF
--- a/fire.py
+++ b/fire.py
@@ -80,7 +80,8 @@ class FireProx(object):
                 return False
             self.region = config[config_profile_section].get('region', 'us-east-1')
             try:
-                self.client = boto3.session.Session(profile_name=self.profile_name).client('apigateway')
+                self.client = boto3.session.Session(profile_name=self.profile_name,
+                        region_name=self.region).client('apigateway')
                 self.client.get_account()
                 return True
             except:


### PR DESCRIPTION
Fix #28

```
fireprox (master) $ ./fire.py --profile_name jmerckle --region us-east-1 --command list
usage: fire.py [-h] [--profile_name PROFILE_NAME] [--access_key ACCESS_KEY] [--secret_access_key SECRET_ACCESS_KEY] [--session_token SESSION_TOKEN]
               [--region REGION] [--command COMMAND] [--api_id API_ID] [--url URL]

FireProx API Gateway Manager
...
Unable to load AWS credentials
```

When using an AWS profile for credentials, FireProx creates a Boto3 session for the apigateway client without specifying a region.

```
self.client = boto3.session.Session(profile_name=self.profile_name).client('apigateway')
```

The region is required otherwise Boto3 will raise `botocore.exceptions.NoRegionError`.

This PR changes the session establishment to use `self.region`, similar to how it is done when an access key/secret access key/session token is specified on the command line.