### PR TITLE
Add shebang and report error when unsupported command supplied

### DIFF
--- a/fire.py
+++ b/fire.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from multiprocessing import Pool
 from pathlib import Path
 import shutil
@@ -406,6 +407,11 @@ def main():
         result = fp.update_api(fp.api_id, fp.url)
         success = 'Success!' if result else 'Failed!'
         print(f'API Update Complete: {success}')
+
+    else:
+        print(f'[ERROR] Unsupported command: {args.command}\n')
+        print(help_text)
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just a tiny quality-of-life PR to add a shebang and report an error when an unsupported command is supplied.

```
$ ./fire.py --command stop --api_id foobarbaz
[ERROR] Unsupported command: stop

usage: fire.py [-h] [--profile_name PROFILE_NAME] [--access_key ACCESS_KEY] [--secret_access_key SECRET_ACCESS_KEY]
               [--session_token SESSION_TOKEN] [--region REGION] [--command COMMAND] [--api_id API_ID] [--url URL]

FireProx API Gateway Manager

optional arguments:
...
```