### PR TITLE
Change version from python:3.7-slim to 3.9-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.7-slim
+FROM python:3.9-buster
 
 WORKDIR /root/fireprox
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["python", "/root/fireprox/fire.py"]


### PR DESCRIPTION
fix dependency errors on docker build, Change pip to pip3.