### PR TITLE
Add/update some commands and general logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.7-slim
+FROM python:3.9-buster
 
 WORKDIR /root/fireprox
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["python", "/root/fireprox/fire.py"]

--- a/README.md
+++ b/README.md
@@ -55,12 +55,20 @@ usage: **fire.py** [-h] [--access_key ACCESS_KEY]
 
 FireProx API Gateway Manager
 ```
+usage: fire.py [-h] [--profile_name PROFILE_NAME] [--access_key ACCESS_KEY] [--secret_access_key SECRET_ACCESS_KEY] [--session_token SESSION_TOKEN] [--region REGION] [--command COMMAND] [--api_id API_ID] [--url URL]
+
+FireProx API Gateway Manager
+
 optional arguments:
   -h, --help            show this help message and exit
+  --profile_name PROFILE_NAME
+                        AWS Profile Name to store/retrieve credentials
   --access_key ACCESS_KEY
                         AWS Access Key
   --secret_access_key SECRET_ACCESS_KEY
                         AWS Secret Access Key
+  --session_token SESSION_TOKEN
+                        AWS Session Token
   --region REGION       AWS Region
   --command COMMAND     Commands: list, create, delete, update
   --api_id API_ID       API ID

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Being able to hide or continually rotate the source IP address when making web c
 ![Black Hills Information Security](https://www.blackhillsinfosec.com/wp-content/uploads/2016/03/BHIS-logo-L-300x300.png "Black Hills Information Security")
 
 ## Maintainer
-- Follow me on Twitter for more tips, tricks, and tools (or just to say hi)! ([Mike Felch - @ustayready](https://twitter.com/ustayready)) 
+- Follow me on Twitter for more tips, tricks, and tools (or just to say hi)! ([Mike Felch - @ustayready](https://twitter.com/ustayready))
 
 ### Benefits ##
 
@@ -28,8 +28,8 @@ Being able to hide or continually rotate the source IP address when making web c
  * All parameters and URI's are passed through
  * Create, delete, list, or update proxies
  * Spoof X-Forwarded-For source IP header by requesting with an X-My-X-Forwarded-For header
- 
- 
+
+
 ### Disclaimers ##
  * ~~Source IP address is passed to the destination in the X-Forwarded-For header by AWS~~
    * ~~($100 to the first person to figure out how to strip it in the AWS config before it reaches the destination LOL!)~~
@@ -39,7 +39,7 @@ Being able to hide or continually rotate the source IP address when making web c
  * Use of this tool on systems other than those that you own are likely to violate the [AWS Acceptable Use Policy](https://aws.amazon.com/aup/) and could potentially lead to termination or suspension of your AWS account. Further, even use of this tool on systems that you do own, or have explicit permission to perform penetration testing on, is subject to the AWS policy on [penetration testing](https://aws.amazon.com/security/penetration-testing/).
 
 ## Credit ##
-After releasing FireProx publicly, I learned two others were already using the AWS API Gateway technique. Researching the chain of events and having some great conversations, I came to the realization that the only reason I even knew about it was because of these people. I thought it would be cool to give them a few shout-outs and credit, follow these people -- they are awesome. 
+After releasing FireProx publicly, I learned two others were already using the AWS API Gateway technique. Researching the chain of events and having some great conversations, I came to the realization that the only reason I even knew about it was because of these people. I thought it would be cool to give them a few shout-outs and credit, follow these people -- they are awesome.
 
 Credit goes to [Ryan Hanson - @ryHanson](https://twitter.com/ryHanson) who is the first known source of the API Gateway technique
 
@@ -48,18 +48,19 @@ Shout-out to [Mike Hodges - @rmikehodges](https://twitter.com/rmikehodges) for m
 Major shout-out, once again, to my good friend [Ralph May - @ralphte1](https://twitter.com/ralphte1) for introducing me to the technique awhile back.
 
 ## Basic Usage ##
-### Requires AWS access key and secret access key or aws cli configured
+##### Requires AWS access key and secret access key or aws cli configured
 usage: **fire.py** [-h] [--access_key ACCESS_KEY]
                [--secret_access_key SECRET_ACCESS_KEY] [--region REGION]
                [--command COMMAND] [--api_id API_ID] [--url URL]
 
 FireProx API Gateway Manager
 ```
-usage: fire.py [-h] [--profile_name PROFILE_NAME] [--access_key ACCESS_KEY] [--secret_access_key SECRET_ACCESS_KEY] [--session_token SESSION_TOKEN] [--region REGION] [--command COMMAND] [--api_id API_ID] [--url URL]
+usage: fire.py[-h] [--profile_name PROFILE_NAME] [--access_key ACCESS_KEY] [--secret_access_key SECRET_ACCESS_KEY] [--session_token SESSION_TOKEN]
+               [--region REGION] [--command COMMAND] [--api_id API_ID] [--url URL]
 
 FireProx API Gateway Manager
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --profile_name PROFILE_NAME
                         AWS Profile Name to store/retrieve credentials
@@ -69,8 +70,8 @@ optional arguments:
                         AWS Secret Access Key
   --session_token SESSION_TOKEN
                         AWS Session Token
-  --region REGION       AWS Region
-  --command COMMAND     Commands: list, create, delete, update
+  --region REGION       AWS Regions (accepts single region, comma-separated list of regions or file containing regions)
+  --command COMMAND     Commands: list, list_all, create, delete, prune, update
   --api_id API_ID       API ID
   --url URL             URL end-point
 ```
@@ -78,7 +79,50 @@ optional arguments:
 * Examples
 	* examples/google.py: Use a FireProx proxy to scrape Google search.
 	* examples/bing.py: Use a FireProx proxy to scrape Bing search.
-         
+
+### CLI Usage Examples
+
+#### List all APIs from default regions using an AWS profile
+```
+fire.py --profile_name myprofile --command list_all
+```
+Example of output:
+```
+Listing API's from ap-south-1...
+Listing API's from eu-north-1...
+Listing API's from eu-west-3...
+Listing API's from eu-west-2...
+Listing API's from eu-west-1...
+Listing API's from ap-northeast-3...
+Listing API's from ap-northeast-2...
+Listing API's from ap-northeast-1...
+Listing API's from ca-central-1...
+Listing API's from sa-east-1...
+Listing API's from ap-southeast-1...
+Listing API's from ap-southeast-2...
+Listing API's from eu-central-1...
+Listing API's from us-east-1...
+Listing API's from us-east-2...
+Listing API's from us-west-1...
+Listing API's from us-west-2...
+```
+
+#### Remove ALL APIs from regions defined in a text file (one per line)
+```
+fire.py --command prune --region aws-regions.txt
+```
+A confirmation will be required before proceeding:
+```
+This will delete ALL APIs from region(s): ap-south-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,
+ap-northeast-3,ap-northeast-2,ap-northeast-1,ca-central-1,sa-east-1,ap-southeast-1,
+ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2. Proceed? [y/N]
+```
+
+#### Create a new API in a random region from a list of regions
+```
+fire.py --profile_name myprofile --command create --url https://example.com --region aws-regions.txt
+```
+
 ## Installation ##
 You can install and run with the following command:
 

--- a/aws-regions.txt
+++ b/aws-regions.txt
@@ -1,0 +1,17 @@
+ap-south-1
+eu-north-1
+eu-west-3
+eu-west-2
+eu-west-1
+ap-northeast-3
+ap-northeast-2
+ap-northeast-1
+ca-central-1
+sa-east-1
+ap-southeast-1
+ap-southeast-2
+eu-central-1
+us-east-1
+us-east-2
+us-west-1
+us-west-2

--- a/fire.py
+++ b/fire.py
@@ -400,7 +400,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, str]:
     parser.add_argument('--region',
                         help='AWS Region', type=str, default=None)
     parser.add_argument('--command',
-                        help='Commands: list, create, delete, update', type=str, default=None)
+                        help='Commands: list, list_all, create, delete, update', type=str, default=None)
     parser.add_argument('--api_id',
                         help='API ID', type=str, required=False)
     parser.add_argument('--url',
@@ -459,6 +459,13 @@ def main():
                 result = fp.list_api(deleting=False)
         else:
             args.region = region_parsed
+            fp = FireProx(args, help_text)
+            print(f'Listing API\'s from {fp.region}...')
+            result = fp.list_api(deleting=False)
+
+    elif args.command == "list_all":
+        for region in AWS_DEFAULT_REGIONS:
+            args.region = region
             fp = FireProx(args, help_text)
             print(f'Listing API\'s from {fp.region}...')
             result = fp.list_api(deleting=False)

--- a/fire.py
+++ b/fire.py
@@ -422,7 +422,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, str]:
     parser.add_argument('--session_token',
                         help='AWS Session Token', type=str, default=None)
     parser.add_argument('--region',
-                        help='AWS Region', type=str, default=None)
+                        help='AWS Regions (accepts single region, comma-separated list of regions or file containing regions)', type=str, default=None)
     parser.add_argument('--command',
                         help='Commands: list, list_all, create, delete, prune, update', type=str, default=None)
     parser.add_argument('--api_id',

--- a/fire.py
+++ b/fire.py
@@ -274,6 +274,7 @@ class FireProx(object):
             body=template
         )
         resource_id, proxy_url = self.create_deployment(response['id'])
+        result = {"id":response['id'],"proxy_url":proxy_url}
         self.store_api(
             response['id'],
             response['name'],
@@ -283,6 +284,8 @@ class FireProx(object):
             resource_id,
             proxy_url
         )
+        return result
+
 
     def update_api(self, api_id, url):
         if not any([api_id, url]):
@@ -469,7 +472,6 @@ def main():
     :return:
     """
     args, help_text = parse_arguments()
-    #fp = FireProx(args, help_text)
     if args.command == 'list':
         region_parsed = parse_region(args.region)
         if isinstance(region_parsed, list):
@@ -494,12 +496,9 @@ def main():
 
 
     elif args.command == 'create':
-        if args.region is not None:
-            # if region is a file containing regions, choose one randomly
-            if os.path.isfile(args.region):
-                with open(args.region) as f:
-                    regions = [reg.strip() for reg in f.readlines()]
-                    self.region = random.choice(regions)
+        region_parsed = parse_region(args.region, mode="random")
+        args.region = region_parsed
+        fp = FireProx(args, help_text)
         result = fp.create_api(fp.url)
 
 

--- a/fire.py
+++ b/fire.py
@@ -314,6 +314,7 @@ class FireProx(object):
         if not api_id:
             self.error('Please provide a valid API ID')
         retry = 3
+        sleep_time = 3
         success = False
         error_msg = 'Generic error'
         while retry > 0 and not success:
@@ -327,7 +328,8 @@ class FireProx(object):
                     break
                 elif err.response['Error']['Code'] == 'TooManyRequestsException':
                     error_msg = 'Too many requests'
-                    sleep(1)
+                    sleep(sleep_time)
+                    sleep_time *= 2
                 else:
                     error_msg = err.response['Error']['Message']
             except BaseException as e:
@@ -536,9 +538,11 @@ def main():
                     print(f'No API found')
                 else:
                     for api in current_apis:
-                        result = fp.delete_api(api_id=api['id'])
-                        success = 'Success!' if result else 'Failed!'
-                        print(f'Deleting {api["id"]} => {success}')
+                        result, msg = fp.delete_api(api_id=api['id'])
+                        if result:
+                            print(f'Deleting {api["id"]} => Success!')
+                        else:
+                            print(f'Deleting {api["id"]} => Failed! ({msg})')
 
 
     elif args.command == 'update':

--- a/fire.py
+++ b/fire.py
@@ -546,6 +546,11 @@ def main():
 
 
     elif args.command == 'update':
+        region_parsed = parse_region(args.region)
+        if isinstance(region_parsed, list):
+            print(f'[ERROR] More than one region provided for command \'update\'\n')
+            sys.exit(1)
+        fp = FireProx(args, help_text)
         print(f'Updating {fp.api_id} => {fp.url}...')
         result = fp.update_api(fp.api_id, fp.url)
         success = 'Success!' if result else 'Failed!'

--- a/fire.py
+++ b/fire.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shutil
 import tldextract
 import boto3
+import botocore
 import os
 import sys
 import random
@@ -13,6 +14,7 @@ import argparse
 import json
 import configparser
 from typing import Tuple, List, Union, Any, Callable
+from time import sleep
 
 AWS_DEFAULT_REGIONS = [
     "ap-south-1",
@@ -311,15 +313,32 @@ class FireProx(object):
     def delete_api(self, api_id):
         if not api_id:
             self.error('Please provide a valid API ID')
-        items = self.list_api(api_id)
-        for item in items:
-            item_api_id = item['id']
-            if item_api_id == api_id:
+        retry = 3
+        success = False
+        error_msg = 'Generic error'
+        while retry > 0 and not success:
+            try:
                 response = self.client.delete_rest_api(
                     restApiId=api_id
                 )
-                return True
-        return False
+            except botocore.exceptions.ClientError as err:
+                if err.response['Error']['Code'] == 'NotFoundException':
+                    error_msg = 'API not found'
+                    break
+                elif err.response['Error']['Code'] == 'TooManyRequestsException':
+                    error_msg = 'Too many requests'
+                    sleep(1)
+                else:
+                    error_msg = err.response['Error']['Message']
+            except BaseException as e:
+                error_msg = 'Generic error'
+            else:
+                success = True
+                error_msg = ''
+            finally:
+                retry -= 1
+        return success, error_msg
+
 
     def list_api(self, deleted_api_id=None, deleting=False):
         response = self.client.get_rest_apis()
@@ -400,7 +419,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, str]:
     parser.add_argument('--region',
                         help='AWS Region', type=str, default=None)
     parser.add_argument('--command',
-                        help='Commands: list, list_all, create, delete, update', type=str, default=None)
+                        help='Commands: list, list_all, create, delete, prune, update', type=str, default=None)
     parser.add_argument('--api_id',
                         help='API ID', type=str, required=False)
     parser.add_argument('--url',
@@ -463,12 +482,14 @@ def main():
             print(f'Listing API\'s from {fp.region}...')
             result = fp.list_api(deleting=False)
 
+
     elif args.command == "list_all":
         for region in AWS_DEFAULT_REGIONS:
             args.region = region
             fp = FireProx(args, help_text)
             print(f'Listing API\'s from {fp.region}...')
             result = fp.list_api(deleting=False)
+
 
     elif args.command == 'create':
         if args.region is not None:
@@ -479,16 +500,53 @@ def main():
                     self.region = random.choice(regions)
         result = fp.create_api(fp.url)
 
+
     elif args.command == 'delete':
-        result = fp.delete_api(fp.api_id)
-        success = 'Success!' if result else 'Failed!'
-        print(f'Deleting {fp.api_id} => {success}')
+        region_parsed = parse_region(args.region)
+        if region_parsed is None or isinstance(region_parsed, str):
+            args.region = region_parsed
+            fp = FireProx(args, help_text)
+            result, msg = fp.delete_api(fp.api_id)
+            if result:
+                print(f'Deleting {fp.api_id} => Success!')
+            else:
+                print(f'Deleting {fp.api_id} => Failed! ({msg})')
+        else:
+            print(f'[ERROR] More than one region provided for command \'delete\'\n')
+            sys.exit(1)
+
+
+    elif args.command == 'prune':
+        region_parsed = parse_region(args.region)
+        if region_parsed is None:
+            region_parsed = AWS_DEFAULT_REGIONS
+        if isinstance(region_parsed, str):
+            region_parsed = [region_parsed]
+        while True:
+            choice = input(f"This will delete ALL APIs from region(s): {','.join(region_parsed)}. Proceed? [y/N] ") or 'N'
+            if choice.upper() in ['Y', 'N']:
+                break
+        if choice.upper() == 'Y':
+            for region in region_parsed:
+                args.region = region
+                fp = FireProx(args, help_text)
+                print(f'Retrieving API\'s from {region}...')
+                current_apis = fp.list_api(deleting=True)
+                if len(current_apis) == 0:
+                    print(f'No API found')
+                else:
+                    for api in current_apis:
+                        result = fp.delete_api(api_id=api['id'])
+                        success = 'Success!' if result else 'Failed!'
+                        print(f'Deleting {api["id"]} => {success}')
+
 
     elif args.command == 'update':
         print(f'Updating {fp.api_id} => {fp.url}...')
         result = fp.update_api(fp.api_id, fp.url)
         success = 'Success!' if result else 'Failed!'
         print(f'API Update Complete: {success}')
+
 
     else:
         print(f'[ERROR] Unsupported command: {args.command}\n')


### PR DESCRIPTION
This PR adds the following features:

- list_all command to list all apis from default regions
- list command now accept multiple regions as input and show all of them
- region passed as option has precedence over region stored in aws config files
- prune command to remove all apis from specified regions
- option region now accepts a list of regions, either as comma-separated string or file containing regions
- when creating a new api and passing multiple regions, it will choose one randomly
- logic of delete command was changed to avoid iterating over all apis when deleting. Instead, use exceptions to handle specific cases like api not found.