### PR TITLE
Re-factor to support multiple space-separated urls and persistent tracking of active APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ optional arguments:
   --command COMMAND     Commands: list, create, delete, update
   --api_id API_ID       API ID
   --url URL             URL end-point
+  --urls URLS           URL end-points (space separated)
 ```
 
 * Examples


### PR DESCRIPTION
updated create_api, get_template, and delete_api methods to support multiple space-separated urls, created endpoints.json to store active endpoints, with failback to listing APIs starting with fireprox if not found, updated list_apis to only return apis starting with fireprox_